### PR TITLE
sDAdGLyv-qt-62

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
 
 set(CMAKE_CXX_STANDARD 23)
+set(QT6_MIN_VERSION 6.2)
 
 include_directories(.)
 
@@ -61,7 +62,7 @@ install(TARGETS harvest
         )
 
 
-find_package(Qt6 REQUIRED
+find_package(Qt6 ${QT6_MIN_VERSION} REQUIRED
         Core
         Gui
         Widgets

--- a/main.cpp
+++ b/main.cpp
@@ -29,12 +29,17 @@ int main(int argc, char* argv[])
 	const QString conf_dir_name{ "Harvest Timer Qt" };
 	const QDir config_dir = get_config_directory(conf_dir_name);
 
-	if(!QNetworkInformation::loadDefaultBackend())
-	{
-		QMessageBox::warning(nullptr,
-							 QApplication::translate("HarvestHandler", "Error Loading Network Information"),
-							 QApplication::translate("HarvestHandler", "There was an error loading the system network information manager, the application will not be aware of changes in the network status"));
-	}
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 4, 0))
+    if (!QNetworkInformation::loadDefaultBackend())
+# else
+    if (!QNetworkInformation::load(QNetworkInformation::availableBackends().at(0)))
+#endif
+    {
+        QMessageBox::warning(nullptr,
+                             QApplication::translate("HarvestHandler", "Error Loading Network Information"),
+                             QApplication::translate("HarvestHandler",
+                                                     "There was an error loading the system network information manager, the application will not be aware of changes in the network status"));
+    }
 
 	MainWindow w(config_dir);
 

--- a/main.cpp
+++ b/main.cpp
@@ -32,7 +32,7 @@ int main(int argc, char* argv[])
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 4, 0))
     if (!QNetworkInformation::loadDefaultBackend())
 # else
-    if (!QNetworkInformation::load(QNetworkInformation::availableBackends().at(0)))
+    if (!QNetworkInformation::load(QNetworkInformation::availableBackends().first()))
 #endif
     {
         QMessageBox::warning(nullptr,


### PR DESCRIPTION
Added support for Qt6.2 LTS QNetworkInformation backend loading and limited Qt6 minimum version to, again, 6.2

The application is fully working under Qt6.2 with only these changes