### PR TITLE
Fixed user_id not being deleted

### DIFF
--- a/harvesthandler.cpp
+++ b/harvesthandler.cpp
@@ -369,10 +369,10 @@ void HarvestHandler::get_projects_data(const QJsonDocument& json_payload, std::v
 void HarvestHandler::get_user_details(const QString &scope)
 {
     account_id = scope.split("%3A")[1];
-    settings_manager->add_setting(account_id_key, account_id);
+    settings_manager->add_setting(user_details_group, account_id_key, account_id);
 
     user_id = get_user_id();
-	settings_manager->add_setting(user_id_key, user_id);
+	settings_manager->add_setting(user_details_group, user_id_key, user_id);
 
     emit ready();
 }
@@ -385,7 +385,7 @@ void HarvestHandler::load_account_id()
     // Setting this for a while for retro-compatibility
     if (user_id.isEmpty()) {
         user_id = get_user_id();
-        settings_manager->add_setting(user_id_key, user_id);
+        settings_manager->add_setting(user_details_group, user_id_key, user_id);
     }
 }
 
@@ -693,7 +693,7 @@ QString HarvestHandler::get_http_message(const QString& message) {
 
 void HarvestHandler::logout_cleanup() {
     auth_file.remove();
-    settings_manager->remove_setting(account_id_key);
+    settings_manager->remove_setting(user_details_group);
 }
 
 QString HarvestHandler::get_user_id() {

--- a/harvesthandler.h
+++ b/harvesthandler.h
@@ -16,6 +16,7 @@
 
 static const char *const account_id_key = "account_id";
 static const char *const user_id_key = "user_id";
+static const char *const user_details_group{"User"};
 
 class HarvestHandler : public QObject
 {

--- a/settingsmanager.cpp
+++ b/settingsmanager.cpp
@@ -29,9 +29,11 @@ SettingsManager::SettingsManager(const QDir& config_dir)
 
 SettingsManager::~SettingsManager() = default;
 
-void SettingsManager::add_setting(const QString& key, const QVariant &value)
+void SettingsManager::add_setting(const QString& group, const QString& key, const QVariant &value)
 {
+    settings.beginGroup(group);
 	settings.setValue(key, value);
+    settings.endGroup();
 }
 
 QVariant SettingsManager::get_setting(const QString& key)

--- a/settingsmanager.h
+++ b/settingsmanager.h
@@ -16,7 +16,7 @@ class SettingsManager
 
 		static void reset_instance();
 
-		void add_setting(const QString& key, const QVariant &value);
+		void add_setting(const QString& group, const QString& key, const QVariant &value);
 
 		QVariant get_setting(const QString& key);
 


### PR DESCRIPTION
All user details will now go into a specific group, which will allow the app to easily clean them up by deleting the group