### PR TITLE
Fixed loading the right user details

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,9 @@ add_executable(harvest
         showorhideaction.cpp
         showorhideaction.h
         logoutaction.cpp
-        logoutaction.h)
+        logoutaction.h
+        customcombobox.cpp
+        customcombobox.h)
 
 if (QT_VERSION VERSION_LESS 6.4)
     set_property(TARGET harvest PROPERTY AUTORCC_OPTIONS "--no-zstd")

--- a/addtaskform.ui
+++ b/addtaskform.ui
@@ -15,13 +15,31 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="2" column="0" colspan="2">
-    <widget class="QTextEdit" name="notes_text_edit"/>
+    <widget class="QTextEdit" name="notes_text_edit">
+     <property name="placeholderText">
+      <string>Add A Custom Note…</string>
+     </property>
+    </widget>
    </item>
    <item row="1" column="0" colspan="2">
-    <widget class="QComboBox" name="task_dropdown"/>
+    <widget class="CustomComboBox" name="task_dropdown">
+     <property name="editable">
+      <bool>false</bool>
+     </property>
+     <property name="placeholderText">
+      <string/>
+     </property>
+    </widget>
    </item>
    <item row="0" column="0" colspan="2">
-    <widget class="QComboBox" name="project_dropdown"/>
+    <widget class="CustomComboBox" name="project_dropdown">
+     <property name="editable">
+      <bool>false</bool>
+     </property>
+     <property name="placeholderText">
+      <string/>
+     </property>
+    </widget>
    </item>
    <item row="4" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
@@ -53,6 +71,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>CustomComboBox</class>
+   <extends>QComboBox</extends>
+   <header>customcombobox.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/customcombobox.cpp
+++ b/customcombobox.cpp
@@ -1,0 +1,12 @@
+//
+// Created by jorge on 07/02/23.
+//
+
+#include "customcombobox.h"
+#include <QAbstractItemView>
+
+CustomComboBox::CustomComboBox(QWidget *parent) : QComboBox(parent) {
+    this->view()->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    this->view()->setMaximumHeight(parent->height());
+    this->view()->window()->setMaximumHeight(parent->height());
+}

--- a/customcombobox.h
+++ b/customcombobox.h
@@ -1,0 +1,16 @@
+//
+// Created by jorge on 07/02/23.
+//
+
+#ifndef HARVESTTIMER_QT_CMAKE_CUSTOMCOMBOBOX_H
+#define HARVESTTIMER_QT_CMAKE_CUSTOMCOMBOBOX_H
+
+#include<QComboBox>
+
+class CustomComboBox : public QComboBox {
+public:
+    explicit CustomComboBox(QWidget *parent);
+};
+
+
+#endif //HARVESTTIMER_QT_CMAKE_CUSTOMCOMBOBOX_H

--- a/edittaskform.ui
+++ b/edittaskform.ui
@@ -18,10 +18,10 @@
     <widget class="QTextEdit" name="notes_text_edit"/>
    </item>
    <item row="1" column="0" colspan="2">
-    <widget class="QComboBox" name="task_dropdown"/>
+    <widget class="CustomComboBox" name="task_dropdown"/>
    </item>
    <item row="0" column="0" colspan="2">
-    <widget class="QComboBox" name="project_dropdown"/>
+    <widget class="CustomComboBox" name="project_dropdown"/>
    </item>
    <item row="4" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
@@ -56,6 +56,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>CustomComboBox</class>
+   <extends>QComboBox</extends>
+   <header>customcombobox.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/harvesthandler.cpp
+++ b/harvesthandler.cpp
@@ -335,8 +335,8 @@ void HarvestHandler::get_user_details(const QString &scope) {
 
 // the account id was previously extracted and saved in a settings file
 void HarvestHandler::load_user_ids() {
-    account_id = settings_manager->get_setting(account_id_key).toString();
-    user_id = settings_manager->get_setting(user_id_key).toString();
+    account_id = settings_manager->get_setting(user_details_group, account_id_key).toString();
+    user_id = settings_manager->get_setting(user_details_group, user_id_key).toString();
     // Setting this for a while for retro-compatibility
     if (user_id.isEmpty()) {
         user_id = get_user_id();

--- a/settingsmanager.cpp
+++ b/settingsmanager.cpp
@@ -36,10 +36,14 @@ void SettingsManager::add_setting(const QString& group, const QString& key, cons
     settings.endGroup();
 }
 
-QVariant SettingsManager::get_setting(const QString& key)
+QVariant SettingsManager::get_setting(const QString &group, const QString &key)
 {
-	return settings.value(key);
-
+	QVariant value{settings.value(group + "/" + key)};
+    // Setting this for a while for retro-compatibility
+    if (value.isNull()) {
+        value = settings.value(key);
+    }
+    return value;
 }
 
 void SettingsManager::remove_setting(const QString& key) {

--- a/settingsmanager.h
+++ b/settingsmanager.h
@@ -18,7 +18,7 @@ class SettingsManager
 
 		void add_setting(const QString& group, const QString& key, const QVariant &value);
 
-		QVariant get_setting(const QString& key);
+		QVariant get_setting(const QString &group, const QString &key);
 
         void remove_setting(const QString& key);
 


### PR DESCRIPTION
 If users don't logout (it will be recommended for this release), some details may be placed in different groups of their settings.ini file, so let's make sure we cover for that, and also, that we grab the right detail if it's placed under both the General and User groups