### PR TITLE
No longer calling stop before start

### DIFF
--- a/harvesthandler.cpp
+++ b/harvesthandler.cpp
@@ -328,7 +328,7 @@ void HarvestHandler::get_user_details(const QString &scope) {
     settings_manager->add_setting(user_details_group, account_id_key, account_id);
 
     user_id = get_user_id();
-	settings_manager->add_setting(user_details_group, user_id_key, user_id);
+    settings_manager->add_setting(user_details_group, user_id_key, user_id);
 
     emit ready();
 }
@@ -599,7 +599,12 @@ bool HarvestHandler::default_error_check(QNetworkReply *reply, const QString &ba
     }
     if (reply->error() != QNetworkReply::NetworkError::NoError) {
         const QJsonDocument error_report{read_close_reply(const_cast<QNetworkReply *>(reply))};
-        const QString error_string{base_error_body + error_report["error"].toString()};
+        qDebug() << "received error: " << reply->error();
+        qDebug() << "error message: " << error_report;
+
+        const QString error_string{(error_report["error"].isNull() ?
+                                    error_report["error"] :
+                                    error_report["message"]).toString()};
         QMessageBox::information(nullptr, base_error_title, error_string);
         return true;
     }

--- a/tasksscrollarea.cpp
+++ b/tasksscrollarea.cpp
@@ -9,12 +9,8 @@
 #include <QMessageBox>
 
 TasksScrollArea::TasksScrollArea(QWidget *widget)
-        : CustomScrollArea(widget)
-        , timer{QTimer(this)}
-        , runningTask{}
-        , runningTaskWidget{nullptr}
-        , lookup_date{QDate::currentDate()}
-        {
+        : CustomScrollArea(widget), timer{QTimer(this)}, runningTask{}, runningTaskWidget{nullptr},
+          lookup_date{QDate::currentDate()} {
     timer.setInterval(timer_seconds * 1000);
 }
 
@@ -61,7 +57,7 @@ void TasksScrollArea::start_task(const Task *task, TaskWidget *task_widget) {
 
 void TasksScrollArea::start_task_locally(const Task *task, TaskWidget *task_widget) {
     // If there is a currently running task we want to set_stopped it, because we're only allowed to track one task at a time
-    stop_current_task();
+    stop_task_locally();
 
     // Restart timer
     timer.start();
@@ -96,9 +92,6 @@ void TasksScrollArea::delete_task(const Task *task, TaskWidget *task_widget) {
 }
 
 void TasksScrollArea::stop_current_task() {
-    if (runningTaskWidget == nullptr)
-        return;
-
     // stopping remotely takes longer due to the network overhead, so we kick it first and then stop locally
     // to try and be as accurate as possible
     // TODO maybe stop locally on success response received instead of always stopping locally
@@ -108,6 +101,9 @@ void TasksScrollArea::stop_current_task() {
 }
 
 void TasksScrollArea::stop_task_locally() {
+    if (runningTaskWidget == nullptr)
+        return;
+
     disconnect(runningTaskWidget, &TaskWidget::task_stopped, nullptr, nullptr);
     runningTaskWidget->set_stopped();
     runningTaskWidget = nullptr;
@@ -132,7 +128,7 @@ void TasksScrollArea::task_added(const Task *task) {
     connect(task_widget, &TaskWidget::task_unfavourited, this, &TasksScrollArea::unfavourite_task);
     bool inserted{MapUtils::map_insert_or_create_set(task_widgets, task->date, task_widget)};
 
-    if(!inserted) {
+    if (!inserted) {
         delete task_widget;
         return;
     }


### PR DESCRIPTION
The start endpoint will now stop the previous task, so we just need to update the widgets accordingly