### PR TITLE
Updated release workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -39,7 +39,7 @@ jobs:
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: |
         echo "Configuring a CMake Release environment"
-        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_INSTALL_PREFIX=/usr/bin
+        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_INSTALL_PREFIX=/usr
     - name: Build
       # Build your program with the given configuration
       run: |
@@ -108,14 +108,7 @@ jobs:
           mkdir -p .pkg/DEBIAN
           
           find ./usr -type f -exec install -Dm755 '{}' "${{github.workspace}}/.pkg/{}" \;
-          install -Dm644 "./resources/desktop/harvest.svg" "${{github.workspace}}/.pkg/usr/share/icons/hicolor/scalable/apps/harvest.svg"
-          install -Dm755 "./resources/desktop/harvest.desktop" "${{github.workspace}}/.pkg/usr/share/applications/harvest.desktop"
-          install -Dm644 "./debian/copyright" "${{github.workspace}}/.pkg/DEBIAN/copyright";
           sed -i "s/\${copyright_year}/$(date '+%Y')/g" ${{github.workspace}}/.pkg/DEBIAN/copyright
-          
-          for _size in 16 24 32 48 64 96 128 256 512; do
-            install -Dm644 "./resources/icons/hicolor/${_size}x${_size}.png" "${{github.workspace}}/.pkg/usr/share/icons/hicolor/${_size}x${_size}/apps/harvest.png"
-          done
       - name: Archive Package Directory
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -44,7 +44,7 @@ jobs:
       # Build your program with the given configuration
       run: |
         echo "Building binary"
-        cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+        cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} -j $(nproc)
     - name: Preparing Artifact
       run: |
         dist_dir="${{github.workspace}}/res"

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -108,6 +108,7 @@ jobs:
           mkdir -p .pkg/DEBIAN
           
           find ./usr -type f -exec install -Dm755 '{}' "${{github.workspace}}/.pkg/{}" \;
+          install -Dm644 "./debian/copyright" "${{github.workspace}}/.pkg/DEBIAN/copyright";
           sed -i "s/\${copyright_year}/$(date '+%Y')/g" ${{github.workspace}}/.pkg/DEBIAN/copyright
       - name: Archive Package Directory
         uses: actions/upload-artifact@v3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,10 +81,9 @@ find_package(Qt6 ${QT6_MIN_VERSION} REQUIRED
         Widgets
         Network
         LinguistTools
-        Svg
         )
 
-target_link_libraries(harvest Qt6::Core Qt6::Widgets Qt6::Gui Qt6::Network Qt6::Svg)
+target_link_libraries(harvest Qt6::Core Qt6::Widgets Qt6::Gui Qt6::Network)
 
 qt6_add_translations(harvest TS_FILES
         harvesttimer-qt_es_ES.ts


### PR DESCRIPTION
It could be simplified by the amount of icons we no longer require, and I've also added a -j flag for cmake to use as many cores as available and speed up build time when available